### PR TITLE
Fix wrong path for Mono-based test assets

### DIFF
--- a/System.Drawing.Common.TestData.nuspec
+++ b/System.Drawing.Common.TestData.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
   <metadata minClientVersion="2.8.1">
     <id>System.Drawing.Common.TestData</id>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <title>Test data for System.Drawing.Common tests</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -32,25 +32,25 @@
     <file src="System.Drawing.Common.TestData\bitmaps\64x64_one_entry_8bit.ico" target="content\bitmaps\64x64_one_entry_8bit.ico" />
     <file src="System.Drawing.Common.TestData\bitmaps\invalid.ico" target="content\bitmaps\invalid.ico" />
     <file src="System.Drawing.Common.TestData\bitmaps\telescope_01.wmf" target="content\bitmaps\telescope_01.wmf" />
-    <file src="System.Drawing.Common.TestData\bitmaps\1bit.png" target="System.Drawing.Common.TestData\bitmaps\1bit.png" />
-    <file src="System.Drawing.Common.TestData\bitmaps\4bit.png" target="System.Drawing.Common.TestData\bitmaps\4bit.png" />
-    <file src="System.Drawing.Common.TestData\bitmaps\81674-2bpp.png" target="System.Drawing.Common.TestData\bitmaps\81674-2bpp.png" />
-    <file src="System.Drawing.Common.TestData\bitmaps\81773-interlaced.gif" target="System.Drawing.Common.TestData\bitmaps\81773-interlaced.gif" />
-    <file src="System.Drawing.Common.TestData\bitmaps\VisualPng.ico" target="System.Drawing.Common.TestData\bitmaps\VisualPng.ico" />
-    <file src="System.Drawing.Common.TestData\bitmaps\VisualPng1.ico" target="System.Drawing.Common.TestData\bitmaps\VisualPng1.ico" />
-    <file src="System.Drawing.Common.TestData\bitmaps\almogaver-os2.bmp" target="System.Drawing.Common.TestData\bitmaps\almogaver-os2.bmp" />
-    <file src="System.Drawing.Common.TestData\bitmaps\almogaver1bit.bmp" target="ystem.Drawing.Common.TestData\bitmaps\almogaver1bit.bmp" />
-    <file src="System.Drawing.Common.TestData\bitmaps\almogaver24bits.bmp" target="System.Drawing.Common.TestData\bitmaps\almogaver24bits.bmp" />
-    <file src="System.Drawing.Common.TestData\bitmaps\almogaver24bits1.bmp" target="System.Drawing.Common.TestData\bitmaps\almogaver24bits1.bmp" />
-    <file src="System.Drawing.Common.TestData\bitmaps\almogaver32bits.bmp" target="System.Drawing.Common.TestData\bitmaps\almogaver32bits.bmp" />
-    <file src="System.Drawing.Common.TestData\bitmaps\almogaver32bits.tif" target="System.Drawing.Common.TestData\bitmaps\almogaver32bits.tif" />
-    <file src="System.Drawing.Common.TestData\bitmaps\maketransparent.bmp" target="System.Drawing.Common.TestData\bitmaps\maketransparent.bmp" />
-    <file src="System.Drawing.Common.TestData\bitmaps\milkmateya01.emf" target="System.Drawing.Common.TestData\bitmaps\milkmateya01.emf" />
-    <file src="System.Drawing.Common.TestData\bitmaps\nature-greyscale.jpg" target="System.Drawing.Common.TestData\bitmaps\nature-greyscale.jpg" />
-    <file src="System.Drawing.Common.TestData\bitmaps\nature24bits.gif" target="System.Drawing.Common.TestData\bitmaps\nature24bits.gif" />
-    <file src="System.Drawing.Common.TestData\bitmaps\nature24bits.jpg" target="System.Drawing.Common.TestData\bitmaps\nature24bits.jpg" />
-    <file src="System.Drawing.Common.TestData\bitmaps\nature24bits87.gif" target="System.Drawing.Common.TestData\bitmaps\nature24bits87.gif" />
-    <file src="System.Drawing.Common.TestData\bitmaps\non-inverted.bmp" target="System.Drawing.Common.TestData\bitmaps\non-inverted.bmp" />
+    <file src="System.Drawing.Common.TestData\bitmaps\1bit.png" target="content\bitmaps\1bit.png" />
+    <file src="System.Drawing.Common.TestData\bitmaps\4bit.png" target="content\bitmaps\4bit.png" />
+    <file src="System.Drawing.Common.TestData\bitmaps\81674-2bpp.png" target="content\bitmaps\81674-2bpp.png" />
+    <file src="System.Drawing.Common.TestData\bitmaps\81773-interlaced.gif" target="content\bitmaps\81773-interlaced.gif" />
+    <file src="System.Drawing.Common.TestData\bitmaps\VisualPng.ico" target="content\bitmaps\VisualPng.ico" />
+    <file src="System.Drawing.Common.TestData\bitmaps\VisualPng1.ico" target="content\bitmaps\VisualPng1.ico" />
+    <file src="System.Drawing.Common.TestData\bitmaps\almogaver-os2.bmp" target="content\bitmaps\almogaver-os2.bmp" />
+    <file src="System.Drawing.Common.TestData\bitmaps\almogaver1bit.bmp" target="content\bitmaps\almogaver1bit.bmp" />
+    <file src="System.Drawing.Common.TestData\bitmaps\almogaver24bits.bmp" target="content\bitmaps\almogaver24bits.bmp" />
+    <file src="System.Drawing.Common.TestData\bitmaps\almogaver24bits1.bmp" target="content\bitmaps\almogaver24bits1.bmp" />
+    <file src="System.Drawing.Common.TestData\bitmaps\almogaver32bits.bmp" target="content\bitmaps\almogaver32bits.bmp" />
+    <file src="System.Drawing.Common.TestData\bitmaps\almogaver32bits.tif" target="content\bitmaps\almogaver32bits.tif" />
+    <file src="System.Drawing.Common.TestData\bitmaps\maketransparent.bmp" target="content\bitmaps\maketransparent.bmp" />
+    <file src="System.Drawing.Common.TestData\bitmaps\milkmateya01.emf" target="content\bitmaps\milkmateya01.emf" />
+    <file src="System.Drawing.Common.TestData\bitmaps\nature-greyscale.jpg" target="content\bitmaps\nature-greyscale.jpg" />
+    <file src="System.Drawing.Common.TestData\bitmaps\nature24bits.gif" target="content\bitmaps\nature24bits.gif" />
+    <file src="System.Drawing.Common.TestData\bitmaps\nature24bits.jpg" target="content\bitmaps\nature24bits.jpg" />
+    <file src="System.Drawing.Common.TestData\bitmaps\nature24bits87.gif" target="content\bitmaps\nature24bits87.gif" />
+    <file src="System.Drawing.Common.TestData\bitmaps\non-inverted.bmp" target="content\bitmaps\non-inverted.bmp" />
     <file src="System.Drawing.Common.TestData\fonts\CodeNewRoman.otf" target="content\fonts\CodeNewRoman.otf" />
     <file src="System.Drawing.Common.TestData\fonts\CodeNewRoman.ttf" target="content\fonts\CodeNewRoman.ttf" />
     <file src="System.Drawing.Common.TestData\colorProfiles\RSWOP.icm" target="content\colorProfiles\RSWOP.icm" />


### PR DESCRIPTION
@mellinoe I just realized the `content` path is wrong for the test assets I added in #19 . This PR fixes it and bumps the version number.

Apologies.