### PR TITLE
Updating instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,9 @@ P SD:\corefx-testdata\System.IO.Compression.TestData> dotnet pack
     System.IO.Compression.TestData -> D:\corefx-testdata\System.IO.Compression.TestData\bin\Debug\netstandard2.0\System.IO.Compression.TestData.dll
 ```
 
-*Note: Running `dotnet pack` from the root of the `corefx-testdata` project will generate the nuget packages for all the \*.csproj files.*
+The generated nuget file(s) will be located at the same level as the `*.csproj` file:
 
-The generated nuget file(s) will be located in the `bin\Debug` subfolder:
-
-`D:\corefx-testdata\System.IO.Compression.TestData\bin\Debug\System.IO.Compression.TestData.1.0.10.nupkg`
+`D:\corefx-testdata\System.IO.Compression.TestData\System.IO.Compression.TestData.1.0.10.nupkg`
 
 
 #### 3. Test that corefx can import the new nuget package file.


### PR DESCRIPTION
Removing text describing the option to run nuget pack from root. It doesn't work anymore.
Also, the nupkg file is now created at the same level as the csproj file, updating that line.